### PR TITLE
Add Bulk Toggle to Filter Column

### DIFF
--- a/src/FilamentExport.php
+++ b/src/FilamentExport.php
@@ -284,6 +284,7 @@ class FilamentExport
                 ->options($columns)
                 ->columns(4)
                 ->default(array_keys($columns))
+                ->bulkToggleable()
                 ->hidden($action->isFilterColumnsDisabled()),
             \Filament\Forms\Components\KeyValue::make('additional_columns')
                 ->label($action->getAdditionalColumnsFieldLabel())


### PR DESCRIPTION
Adding a bulk toggle to the filter column makes it easier for users who don't want all their data exported, especially if they have a lot of column data but only want to select a few columns to export.